### PR TITLE
Use Gemfile to lock to Jekyll 3.8.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+gem "jekyll", '3.8.7'
+gem "mini_magick"
+gem "exifr"
+gem "jekyll-paginate"
+gem "jekyll-gist"
+gem "jekyll-email-protect"


### PR DESCRIPTION
Some of the plugins being used aren't compatible with the newest Jekyll 4.x.x versions, so this forces the installation of 3.8.7 instead.

When building your site, use `bundle exec jekyll build` and `bundle exec jekyll serve` instead of the old `jekyll build` and jekyll serve`